### PR TITLE
Specify encoding when parsing for version in holidays.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     from distutils.core import setup
 
 
-with codecs.open('holidays.py', 'r') as fd:
+with codecs.open('holidays.py', 'r', 'utf-8') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                         fd.read(), re.MULTILINE).group(1)
 


### PR DESCRIPTION
This allows the package to be installed in non-unicode locales.