### PR TITLE
CHANGE - Removes Liberation Day NL after 2000 (#38)

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2012,8 +2012,6 @@ class Netherlands(HolidayBase):
         # Liberation day
         if year >= 1947 and year <= 2000:
             self[date(year, 5, 5)] = "Bevrijdingsdag"
-        elif year >= 2000 and year % 5 == 0:
-            self[date(year, 5, 5)] = "Bevrijdingsdag"
 
         # Kingsday
         if year >= 2014:

--- a/tests.py
+++ b/tests.py
@@ -813,12 +813,6 @@ class TestNetherlands(unittest.TestCase):
         self.holidays = holidays.NL(years=1900)
         self.assertFalse(date(1900, 5, 5) in self.holidays)
 
-        self.holidays = holidays.NL(years=2010)
-        self.assertTrue(date(2020, 5, 5) in self.holidays)
-
-        self.holidays = holidays.NL(years=2010)
-        self.assertFalse(date(2011, 5, 5) in self.holidays)
-
     def test_ascension_day(self):
         self.holidays = holidays.NL(years=2017)
         self.assertTrue(date(2017, 5, 25) in self.holidays)


### PR DESCRIPTION
Liberation Day ("Bevrijdingsdag") is an official celebratory day in the Netherlands but not a holiday where *everyone* is free from work, although a lot of people (especially those working for the government) do not have to work once every 5 years (`year % 5`; the current logic). Since this does not apply to everyone, this day should be removed from the Dutch holidays.

See #38 for more details.

@j92 Since you implemented the Dutch holidays (Bedankt daarvoor trouwens 😉), could you review this PR?