### PR TITLE
Add Norwegian holidays

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,7 @@ Netherlands         NL       None
 NewZealand          NZ       prov = NTL, AUK, TKI, HKB, WGN, MBH, NSN, CAN, STC, WTL,
                              OTA, STL, CIT
 Northern Ireland             None
+Norway              NO       None
 Portugal            PT       None
 PortugalExt         PTE      *Portugal plus extended days most people have off*
 Scotland                     None

--- a/holidays.py
+++ b/holidays.py
@@ -2133,3 +2133,94 @@ class Netherlands(HolidayBase):
 
 class NL(Netherlands):
     pass
+
+
+class Norway(HolidayBase):
+    """
+    Norwegian holidays.
+    Note that holidays falling on a sunday is "lost",
+    it will not be moved to another day to make up for the collision.
+
+    In Norway, ALL sundays are considered a holiday (https://snl.no/helligdag).
+    Initialize this class with include_sundays=False
+    to not include sundays as a holiday.
+
+    Primary sources:
+    https://lovdata.no/dokument/NL/lov/1947-04-26-1
+    https://no.wikipedia.org/wiki/Helligdager_i_Norge
+    https://www.timeanddate.no/merkedag/norge/
+    """
+    def __init__(self, include_sundays=True, **kwargs):
+        """
+
+        :param include_sundays: Whether to consider sundays as a holiday
+        (which they are in Norway)
+        :param kwargs:
+        """
+        self.country = "NO"
+        self.include_sundays = include_sundays
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        # Add all the sundays of the year before adding the "real" holidays
+        if self.include_sundays:
+            first_day_of_year = date(year, 1, 1)
+            first_sunday_of_year = first_day_of_year\
+                + rd(days=SUNDAY - first_day_of_year.weekday())
+            cur_date = first_sunday_of_year
+
+            while cur_date < date(year+1, 1, 1):
+                assert cur_date.weekday() == SUNDAY
+
+                self[cur_date] = "Søndag"
+                cur_date += rd(days=7)
+
+        # ========= Static holidays =========
+        self[date(year, 1, 1)] = "Første nyttårsdag"
+
+        # Source: https://lovdata.no/dokument/NL/lov/1947-04-26-1
+        if year >= 1947:
+            self[date(year, 5,  1)] = "Arbeidernes dag"
+            self[date(year, 5, 17)] = "Grunnlovsdag"
+
+        # According to https://no.wikipedia.org/wiki/F%C3%B8rste_juledag,
+        # these dates are only valid from year > 1700
+        # Wikipedia has no source for the statement, so leaving this be for now
+        self[date(year, 12, 25)] = "Første juledag"
+        self[date(year, 12, 26)] = "Andre juledag"
+
+        # ========= Moving holidays =========
+        # NOTE: These are probably subject to the same > 1700
+        # restriction as the above dates. The only source I could find for how
+        # long Easter has been celebrated in Norway was
+        # https://www.hf.uio.no/ikos/tjenester/kunnskap/samlinger/norsk-folkeminnesamling/livs-og-arshoytider/paske.html
+        # which says
+        # "(...) has been celebrated for over 1000 years (...)" (in Norway)
+        e = easter(year)
+        maundy_thursday = e - rd(days=3)
+        good_friday = e - rd(days=2)
+        resurrection_sunday = e
+        easter_monday = e + rd(days=1)
+        ascension_thursday = e + rd(days=39)
+        pentecost = e + rd(days=49)
+        pentecost_day_two = e + rd(days=50)
+
+        assert maundy_thursday.weekday() == THURSDAY
+        assert good_friday.weekday() == FRIDAY
+        assert resurrection_sunday.weekday() == SUNDAY
+        assert easter_monday.weekday() == MONDAY
+        assert ascension_thursday.weekday() == THURSDAY
+        assert pentecost.weekday() == SUNDAY
+        assert pentecost_day_two.weekday() == MONDAY
+
+        self[maundy_thursday] = "Skjærtorsdag"
+        self[good_friday] = "Langfredag"
+        self[resurrection_sunday] = "Første påskedag"
+        self[easter_monday] = "Andre påskedag"
+        self[ascension_thursday] = "Kristi himmelfartsdag"
+        self[pentecost] = "Første pinsedag"
+        self[pentecost_day_two] = "Andre pinsedag"
+
+
+class NO(Norway):
+    pass

--- a/tests.py
+++ b/tests.py
@@ -2884,5 +2884,121 @@ class TestPT(unittest.TestCase):
         self.assertTrue(date(2017, 12, 25) in self.holidays)  # Christmas
 
 
+class TestNorway(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays_without_sundays = holidays.Norway(include_sundays=False)
+        self.holidays_with_sundays = holidays.Norway()
+
+    def test_new_years(self):
+        self.assertTrue('1900-01-01' in self.holidays_without_sundays)
+        self.assertTrue('2017-01-01' in self.holidays_without_sundays)
+        self.assertTrue('2999-01-01' in self.holidays_without_sundays)
+
+    def test_easter(self):
+        self.assertTrue('2000-04-20' in self.holidays_without_sundays)
+        self.assertTrue('2000-04-21' in self.holidays_without_sundays)
+        self.assertTrue('2000-04-23' in self.holidays_without_sundays)
+        self.assertTrue('2000-04-24' in self.holidays_without_sundays)
+
+        self.assertTrue('2010-04-01' in self.holidays_without_sundays)
+        self.assertTrue('2010-04-02' in self.holidays_without_sundays)
+        self.assertTrue('2010-04-04' in self.holidays_without_sundays)
+        self.assertTrue('2010-04-05' in self.holidays_without_sundays)
+
+        self.assertTrue('2021-04-01' in self.holidays_without_sundays)
+        self.assertTrue('2021-04-02' in self.holidays_without_sundays)
+        self.assertTrue('2021-04-04' in self.holidays_without_sundays)
+        self.assertTrue('2021-04-05' in self.holidays_without_sundays)
+
+        self.assertTrue('2024-03-28' in self.holidays_without_sundays)
+        self.assertTrue('2024-03-29' in self.holidays_without_sundays)
+        self.assertTrue('2024-03-31' in self.holidays_without_sundays)
+        self.assertTrue('2024-04-01' in self.holidays_without_sundays)
+
+    def test_workers_day(self):
+        self.assertFalse('1900-05-01' in self.holidays_without_sundays)
+        self.assertFalse('1946-05-01' in self.holidays_without_sundays)
+        self.assertTrue('1947-05-01' in self.holidays_without_sundays)
+        self.assertTrue('2017-05-01' in self.holidays_without_sundays)
+        self.assertTrue('2999-05-01' in self.holidays_without_sundays)
+
+    def test_constitution_day(self):
+        self.assertFalse('1900-05-17' in self.holidays_without_sundays)
+        self.assertFalse('1946-05-17' in self.holidays_without_sundays)
+        self.assertTrue('1947-05-17' in self.holidays_without_sundays)
+        self.assertTrue('2017-05-17' in self.holidays_without_sundays)
+        self.assertTrue('2999-05-17' in self.holidays_without_sundays)
+
+    def test_pentecost(self):
+        self.assertTrue('2000-06-11' in self.holidays_without_sundays)
+        self.assertTrue('2000-06-12' in self.holidays_without_sundays)
+
+        self.assertTrue('2010-05-23' in self.holidays_without_sundays)
+        self.assertTrue('2010-05-24' in self.holidays_without_sundays)
+
+        self.assertTrue('2021-05-23' in self.holidays_without_sundays)
+        self.assertTrue('2021-05-24' in self.holidays_without_sundays)
+
+        self.assertTrue('2024-05-19' in self.holidays_without_sundays)
+        self.assertTrue('2024-05-20' in self.holidays_without_sundays)
+
+    def test_christmas(self):
+        self.assertTrue('1901-12-25' in self.holidays_without_sundays)
+        self.assertTrue('1901-12-26' in self.holidays_without_sundays)
+
+        self.assertTrue('2016-12-25' in self.holidays_without_sundays)
+        self.assertTrue('2016-12-26' in self.holidays_without_sundays)
+
+        self.assertTrue('2500-12-25' in self.holidays_without_sundays)
+        self.assertTrue('2500-12-26' in self.holidays_without_sundays)
+
+    def test_sundays(self):
+        """
+        Sundays are considered holidays in Norway
+        :return:
+        """
+        self.assertTrue('1989-12-31' in self.holidays_with_sundays)
+        self.assertTrue('2017-02-05' in self.holidays_with_sundays)
+        self.assertTrue('2017-02-12' in self.holidays_with_sundays)
+        self.assertTrue('2032-02-29' in self.holidays_with_sundays)
+
+    def test_not_holiday(self):
+        """
+        Note: Sundays in Norway are considered holidays,
+        so make sure none of these are actually sundays
+
+        TODO: Should add more dates that are often confused for being a holiday
+        :return:
+        """
+        self.assertFalse('2017-02-06' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-07' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-08' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-09' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-10' in self.holidays_without_sundays)
+
+        self.assertFalse('2001-12-24' in self.holidays_without_sundays)
+        self.assertFalse('2001-05-16' in self.holidays_without_sundays)
+        self.assertFalse('2001-05-18' in self.holidays_without_sundays)
+        self.assertFalse('1999-12-31' in self.holidays_without_sundays)
+        self.assertFalse('2016-12-31' in self.holidays_without_sundays)
+        self.assertFalse('2016-12-27' in self.holidays_without_sundays)
+        self.assertFalse('2016-12-28' in self.holidays_without_sundays)
+
+        self.assertFalse('2017-02-06' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-07' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-08' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-09' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-10' in self.holidays_with_sundays)
+
+        self.assertFalse('2001-12-24' in self.holidays_with_sundays)
+        self.assertFalse('2001-05-16' in self.holidays_with_sundays)
+        self.assertFalse('2001-05-18' in self.holidays_with_sundays)
+        self.assertFalse('1999-12-31' in self.holidays_with_sundays)
+        self.assertFalse('2016-12-31' in self.holidays_with_sundays)
+        self.assertFalse('2016-12-27' in self.holidays_with_sundays)
+        self.assertFalse('2016-12-28' in self.holidays_with_sundays)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In Norway, all Sundays are considered holidays. I can see that a lot of users would want Sunday to not be considered a holiday, so I added a parameter to Norway.\_\_init\_\_ (*include_sundays*) to allow them to control whether they should be considered a holiday or not. Currently, it defaults to True.

I've also used asserts in the code to check that the days of easter always fall on the same weekdays. I believe this is good practice, as something is horribly wrong (for example in dateutils.easter) if this is not true.