### PR TITLE
Changes to Australia holiday class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ MANIFEST
 .coverage
 *.egg-info
 *.pyc
+.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Available Countries
 =================== ======== =============================================================
 Country             Abbr     Provinces/States Available
 =================== ======== =============================================================
-Australia           AU       prov = **ACT** (default), NSW, NT, QLD, SA, TAS, VIC, WA
+Australia           AU       state = ACT, NSW, NT, QLD, SA, TAS, VIC, WA
 Austria             AT       prov = B, K, N, O, S, ST, T, V, **W** (default)
 Canada              CA       prov = AB, BC, MB, NB, NL, NS, NT, NU, **ON** (default),
                              PE, QC, SK, YU
@@ -140,11 +140,11 @@ observed
 
 prov
     A string specifying a province that has unique statutory holidays.
-    (Default: Australia='ACT', Canada='ON', NewZealand=None)
+    (Default: Canada='ON', NewZealand=None)
 
 state
     A string specifying a state that has unique statutory holidays.
-    (Default: UnitedStates=None)
+    (Default: Australia=None, UnitedStates=None)
 
 Methods:
 

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,7 @@ PortugalExt         PTE      *Portugal plus extended days most people have off*
 Scotland                     None
 Spain               ES       prov = AND, ARG, AST, CAN, CAM, CAL, CAT, CVA, EXT, GAL,
                              IBA, ICA, MAD, MUR, NAV, PVA, RIO
+Sweden              SE       None
 UnitedKingdom       UK       None
 UnitedStates        US       state = AL, AK, AS, AZ, AR, CA, CO, CT, DE, DC, FL, GA,
                              GU, HI, ID, IL, IN, IA, KS, KY, LA, ME, MD, MH, MA, MI,

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,7 @@ NewZealand          NZ       prov = NTL, AUK, TKI, HKB, WGN, MBH, NSN, CAN, STC,
                              OTA, STL, CIT
 Northern Ireland             None
 Norway              NO       None
+Poland              PL       None
 Portugal            PT       None
 PortugalExt         PTE      *Portugal plus extended days most people have off*
 Scotland                     None

--- a/holidays.py
+++ b/holidays.py
@@ -2205,3 +2205,105 @@ class Norway(HolidayBase):
 
 class NO(Norway):
     pass
+
+
+class Sweden(HolidayBase):
+    """
+    Swedish holidays.
+    Note that holidays falling on a sunday are "lost",
+    it will not be moved to another day to make up for the collision.
+
+    In Sweden, ALL sundays are considered a holiday
+    (https://sv.wikipedia.org/wiki/Helgdagar_i_Sverige).
+    Initialize this class with include_sundays=False
+    to not include sundays as a holiday.
+
+    Primary sources:
+    https://sv.wikipedia.org/wiki/Helgdagar_i_Sverige
+    """
+    def __init__(self, include_sundays=True, **kwargs):
+        """
+
+        :param include_sundays: Whether to consider sundays as a holiday
+        (which they are in Sweden)
+        :param kwargs:
+        """
+        self.country = "SE"
+        self.include_sundays = include_sundays
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        # Add all the sundays of the year before adding the "real" holidays
+        if self.include_sundays:
+            first_day_of_year = date(year, 1, 1)
+            first_sunday_of_year = first_day_of_year\
+                + rd(days=SUNDAY - first_day_of_year.weekday())
+            cur_date = first_sunday_of_year
+
+            while cur_date < date(year+1, 1, 1):
+                assert cur_date.weekday() == SUNDAY
+
+                self[cur_date] = "Söndag"
+                cur_date += rd(days=7)
+
+        # ========= Static holidays =========
+        self[date(year, 1, 1)] = "Nyårsdagen"
+
+        self[date(year, 1, 6)] = "Trettondedag jul"
+
+        # Source: https://sv.wikipedia.org/wiki/F%C3%B6rsta_maj
+        if year >= 1890:
+            self[date(year, 5,  1)] = "Första maj"
+
+        # Source: https://sv.wikipedia.org/wiki/Sveriges_nationaldag
+        if year >= 2005:
+            self[date(year, 6, 6)] = "Sveriges nationaldag"
+
+        self[date(year, 12, 24)] = "Julafton"
+        self[date(year, 12, 25)] = "Juldagen"
+        self[date(year, 12, 26)] = "Annandag jul"
+        self[date(year, 12, 31)] = "Nyårsafton"
+
+        # ========= Moving holidays =========
+        e = easter(year)
+        maundy_thursday = e - rd(days=3)
+        good_friday = e - rd(days=2)
+        easter_saturday = e - rd(days=1)
+        resurrection_sunday = e
+        easter_monday = e + rd(days=1)
+        ascension_thursday = e + rd(days=39)
+        pentecost = e + rd(days=49)
+        pentecost_day_two = e + rd(days=50)
+
+        assert maundy_thursday.weekday() == THURSDAY
+        assert good_friday.weekday() == FRIDAY
+        assert easter_saturday.weekday() == SATURDAY
+        assert resurrection_sunday.weekday() == SUNDAY
+        assert easter_monday.weekday() == MONDAY
+        assert ascension_thursday.weekday() == THURSDAY
+        assert pentecost.weekday() == SUNDAY
+        assert pentecost_day_two.weekday() == MONDAY
+
+        self[good_friday] = "Långfredagen"
+        self[easter_saturday] = "Påskafton"
+        self[resurrection_sunday] = "Påskdagen"
+        self[easter_monday] = "Annandag påsk"
+        self[ascension_thursday] = "Kristi himmelsfärdsdag"
+        self[pentecost] = "Pingstafton"
+        self[pentecost_day_two] = "Pingstdagen"
+
+        # Midsummer evening. Friday between June 19th and June 25th
+        self[date(year, 6, 19) + rd(weekday=FR)] = "Midsommarafton"
+
+        # Midsummer day. Saturday between June 20th and June 26th
+        self[date(year, 6, 20) + rd(weekday=SA)] = "Midsommardagen"
+
+        # All saints evening. Friday between October 30th and November 5th
+        self[date(year, 10, 30) + rd(weekday=FR)] = "Allhelgonaafton"
+
+        # All saints day. Friday between October 31th and November 6th
+        self[date(year, 10, 31) + rd(weekday=SA)] = "Alla helgons dag"
+
+
+class SE(Sweden):
+    pass

--- a/holidays.py
+++ b/holidays.py
@@ -1303,11 +1303,10 @@ class NZ(NewZealand):
 
 
 class Australia(HolidayBase):
-    PROVINCES = ['ACT', 'NSW', 'NT', 'QLD', 'SA', 'TAS', 'VIC', 'WA']
+    STATES = ['ACT', 'NSW', 'NT', 'QLD', 'SA', 'TAS', 'VIC', 'WA']
 
     def __init__(self, **kwargs):
         self.country = 'AU'
-        self.prov = kwargs.pop('prov', kwargs.pop('state', 'ACT'))
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
@@ -1330,19 +1329,19 @@ class Australia(HolidayBase):
         # Australia Day
         jan26 = date(year, 1, 26)
         if year >= 1935:
-            if self.prov == 'NSW' and year < 1946:
+            if self.state == 'NSW' and year < 1946:
                 name = "Anniversary Day"
             else:
                 name = "Australia Day"
             self[jan26] = name
             if self.observed and year >= 1946 and jan26.weekday() in WEEKEND:
                 self[jan26 + rd(weekday=MO)] = name + " (Observed)"
-        elif year >= 1888 and self.prov != 'SA':
+        elif year >= 1888 and self.state != 'SA':
             name = "Anniversary Day"
             self[jan26] = name
 
         # Adelaide Cup
-        if self.prov == 'SA':
+        if self.state == 'SA':
             name = "Adelaide Cup"
             if year >= 2006:
                 # subject to proclamation ?!?!
@@ -1351,15 +1350,15 @@ class Australia(HolidayBase):
                 self[date(year, 3, 1) + rd(weekday=MO(+3))] = name
 
         # Canberra Day
-        if self.prov == 'ACT':
+        if self.state == 'ACT':
             name = "Canberra Day"
             self[date(year, 3, 1) + rd(weekday=MO(+2))] = name
 
         # Easter
         self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
-        if self.prov in ('ACT', 'NSW', 'NT', 'QLD', 'SA', 'VIC'):
+        if self.state in ('ACT', 'NSW', 'NT', 'QLD', 'SA', 'VIC'):
             self[easter(year) + rd(weekday=SA(-1))] = "Easter Saturday"
-        if self.prov == 'NSW':
+        if self.state == 'NSW':
             self[easter(year)] = "Easter Sunday"
         self[easter(year) + rd(weekday=MO)] = "Easter Monday"
 
@@ -1369,14 +1368,14 @@ class Australia(HolidayBase):
             apr25 = date(year, 4, 25)
             self[apr25] = name
             if self.observed:
-                if apr25.weekday() == SATURDAY and self.prov in ('WA', 'NT'):
+                if apr25.weekday() == SATURDAY and self.state in ('WA', 'NT'):
                     self[apr25 + rd(weekday=MO)] = name + " (Observed)"
                 elif (apr25.weekday() == SUNDAY and
-                      self.prov in ('ACT', 'QLD', 'SA', 'WA', 'NT')):
+                      self.state in ('ACT', 'QLD', 'SA', 'WA', 'NT')):
                     self[apr25 + rd(weekday=MO)] = name + " (Observed)"
 
         # Western Australia Day
-        if self.prov == 'WA' and year > 1832:
+        if self.state == 'WA' and year > 1832:
             if year >= 2015:
                 name = "Western Australia Day"
             else:
@@ -1390,14 +1389,14 @@ class Australia(HolidayBase):
             name = "King's Birthday"
         if year >= 1936:
             name = "Queen's Birthday"
-            if self.prov == 'QLD':
+            if self.state == 'QLD':
                 if year == 2012:
                     self[date(year, 10, 1)] = name
                     self[date(year, 6, 11)] = "Queen's Diamond Jubilee"
                 else:
                     dt = date(year, 6, 1) + rd(weekday=MO(+2))
                     self[dt] = name
-            elif self.prov == 'WA':
+            elif self.state == 'WA':
                 # by proclamation ?!?!
                 self[date(year, 10, 1) + rd(weekday=MO(-1))] = name
             else:
@@ -1409,32 +1408,32 @@ class Australia(HolidayBase):
             self[date(year, 11, 9)] = name  # Edward VII
 
         # Picnic Day
-        if self.prov == 'NT':
+        if self.state == 'NT':
             name = "Picnic Day"
             self[date(year, 8, 1) + rd(weekday=MO)] = name
 
         # Labour Day
         name = "Labour Day"
-        if self.prov in ('NSW', 'ACT', 'SA'):
+        if self.state in ('NSW', 'ACT', 'SA'):
             self[date(year, 10, 1) + rd(weekday=MO)] = name
-        elif self.prov == 'WA':
+        elif self.state == 'WA':
             self[date(year, 3, 1) + rd(weekday=MO)] = name
-        elif self.prov == 'VIC':
+        elif self.state == 'VIC':
             self[date(year, 3, 1) + rd(weekday=MO(+2))] = name
-        elif self.prov == 'QLD':
+        elif self.state == 'QLD':
             if 2013 <= year <= 2015:
                 self[date(year, 10, 1) + rd(weekday=MO)] = name
             else:
                 self[date(year, 5, 1) + rd(weekday=MO)] = name
-        elif self.prov == 'NT':
+        elif self.state == 'NT':
             name = "May Day"
             self[date(year, 5, 1) + rd(weekday=MO)] = name
-        elif self.prov == 'TAS':
+        elif self.state == 'TAS':
             name = "Eight Hours Day"
             self[date(year, 3, 1) + rd(weekday=MO(+2))] = name
 
         # Family & Community Day
-        if self.prov == 'ACT':
+        if self.state == 'ACT':
             name = "Family & Community Day"
             if 2007 <= year <= 2009:
                 self[date(year, 11, 1) + rd(weekday=TU)] = name
@@ -1454,7 +1453,7 @@ class Australia(HolidayBase):
                 self[dt] = name
 
         # Melbourne Cup
-        if self.prov == 'VIC':
+        if self.state == 'VIC':
             name = "Melbourne Cup"
             self[date(year, 11, 1) + rd(weekday=TU)] = name
 
@@ -1466,7 +1465,7 @@ class Australia(HolidayBase):
             self[date(year, 12, 27)] = name + " (Observed)"
 
         # Boxing Day
-        if self.prov == 'SA':
+        if self.state == 'SA':
             name = "Proclamation Day"
         else:
             name = "Boxing Day"

--- a/holidays.py
+++ b/holidays.py
@@ -1953,7 +1953,8 @@ class Czech(HolidayBase):
             "Nový rok"
 
         e = easter(year)
-        self[e - rd(days=2)] = "Velký pátek"
+        if year <= 1951 or year >= 2016:
+            self[e - rd(days=2)] = "Velký pátek"
         self[e + rd(days=1)] = "Velikonoční pondělí"
 
         if year >= 1951:

--- a/holidays.py
+++ b/holidays.py
@@ -2307,3 +2307,107 @@ class Sweden(HolidayBase):
 
 class SE(Sweden):
     pass
+
+
+class Poland(HolidayBase):
+    """
+    Polish holidays.
+    Note that holidays falling on a sunday is "lost",
+    it will not be moved to another day to make up for the collision.
+
+    In Poland, ALL sundays are considered a holiday.
+    Initialize this class with include_sundays=False
+    to not include sundays as a holiday.
+
+    Primary sources:
+    https://en.wikipedia.org/wiki/Public_holidays_in_Poland
+    https://pl.wikipedia.org/wiki/Dni_wolne_od_pracy_w_Polsce
+    https://pl.wikipedia.org/wiki/%C5%9Awi%C4%99ta_pa%C5%84stwowe_w_Polsce
+    """
+    def __init__(self, public_only=True, include_sundays=True, **kwargs):
+        """
+
+        :param include_sundays: Whether to consider sundays as a holiday
+        (which they are in Poland)
+        :param public_only: Wheter to consider only Public holidays
+        (i.e. non-working days)
+        :param kwargs:
+        """
+        self.country = 'PL'
+        self.public_only = public_only
+        self.include_sundays = include_sundays
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+
+        # Add all the sundays of the year before adding the "real" holidays
+        if self.include_sundays:
+            first_day_of_year = date(year, 1, 1)
+            first_sunday_of_year = first_day_of_year\
+                + rd(days=SUNDAY - first_day_of_year.weekday())
+            cur_date = first_sunday_of_year
+
+            while cur_date < date(year+1, 1, 1):
+                assert cur_date.weekday() == SUNDAY
+
+                self[cur_date] = "Niedziela"
+                cur_date += rd(days=7)
+
+        # ======= Non-working days =======
+        if year >= 1989 or year in range(1937, 1945):
+            # Independence Day
+            self[date(year, 11, 11)] = "Narodowe Święto Niepodległości"
+        if year >= 1919:
+            # Constitution Day
+            self[date(year, 5, 3)] = "Święto Narodowe Trzeciego Maja"
+        if year >= 1951:  # date of the bill that established the holidays
+            # New Years
+            self[date(year, 1, 1)] = "Nowy rok"
+            # Epiphany (added in 2011)
+            if year >= 2011:
+                self[date(year, 1, 6)] = "Święto Trzech Króli"
+            e = easter(year)
+            # Easter Sunday
+            self[e] = "Niedziela Wielkanocna"
+            # Easter Monday
+            self[e + rd(days=1)] = "Poniedziałek Wielkanocny"
+            # 1st of May (so called "Work Holiday")
+            self[date(year, 5, 1)] = "Święto Pracy"
+            # Pentecost
+            self[e + rd(days=49)] = "Zielone Świątki"
+            # Corpus Christi
+            self[e + rd(days=60)] = "Dzień Bożego Ciała"
+            if year < 1961 or year >= 1989:
+                # Assumption of the Blessed Virgin Mary
+                self[date(year, 8, 15)] = \
+                    "Wniebowzięcie Najświętszej Marii Panny"
+            # All Saints' Day
+            self[date(year, 11, 1)] = "Uroczystość Wszystkich Świętych"
+            # first day of Christmas
+            self[date(year, 12, 25)] = "pierwszy dzień Bożego Narodzenia"
+            # second day of Christmas
+            self[date(year, 12, 26)] = "drugi dzień Bożego Narodzenia"
+
+        # ===== the rest of National Holidays =====
+        if not self.public_only:
+            if year >= 2011:
+                self[date(year, 3, 1)] = \
+                    "Narodowy Dzień Pamięci 'Żołnierzy Wyklętych'"
+            if year >= 2015:
+                self[date(year, 5, 8)] = "Narodowy Dzień Zwycięstwa"
+            if year >= 2009:
+                self[date(year, 8, 1)] = \
+                    "Narodowy Dzień Pamięci Powstania Warszawskiego"
+            if year >= 2005:
+                self[date(year, 8, 31)] = "Dzień Solidarności i Wolności"
+            if year in range(1945, 2015):
+                self[date(year, 5, 9)] = \
+                    "Narodowe Święto Zwycięstwa i Wolności"
+            if year in range(1945, 1990):
+                self[date(year, 7, 22)] = "Narodowe Święto Odrodzenia Polski"
+            if year in range(1945, 1990):
+                self[date(year, 11, 7)] = "Rocznica Rewolucji Październikowej"
+
+
+class PL(Poland):
+    pass

--- a/holidays.py
+++ b/holidays.py
@@ -1320,8 +1320,6 @@ class Australia(HolidayBase):
         # VIC:  Public Holidays Act 1993
         # WA:   Public and Bank Holidays Act 1972
 
-        # TODO do more research on history of Aus holidays
-
         # New Year's Day
         name = "New Year's Day"
         jan1 = date(year, 1, 1)
@@ -1355,7 +1353,7 @@ class Australia(HolidayBase):
         # Canberra Day
         if self.prov == 'ACT':
             name = "Canberra Day"
-            self[date(year, 3, 1) + rd(weekday=MO(+1))] = name
+            self[date(year, 3, 1) + rd(weekday=MO(+2))] = name
 
         # Easter
         self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
@@ -1440,37 +1438,20 @@ class Australia(HolidayBase):
             name = "Family & Community Day"
             if 2007 <= year <= 2009:
                 self[date(year, 11, 1) + rd(weekday=TU)] = name
-            elif year == 2010:
-                # first Monday of the September/October school holidays
+            else:
+                # First Monday of the September/October school holidays
                 # moved to the second Monday if this falls on Labour day
-                # TODO need a formula for the ACT school holidays then
+                # The following formula works until at least 2020
                 # http://www.cmd.act.gov.au/communication/holidays
-                self[date(year, 9, 26)] = name
-            elif year == 2011:
-                self[date(year, 10, 10)] = name
-            elif year == 2012:
-                self[date(year, 10, 8)] = name
-            elif year == 2013:
-                self[date(year, 9, 30)] = name
-            elif year == 2014:
-                self[date(year, 9, 29)] = name
-            elif year == 2015:
-                self[date(year, 9, 28)] = name
-            elif year == 2016:
-                self[date(year, 9, 26)] = name
-            elif 2017 <= year <= 2020:
                 labour_day = date(year, 10, 1) + rd(weekday=MO)
-                if year == 2017:
-                    dt = date(year, 9, 23) + rd(weekday=MO)
-                elif year == 2018:
-                    dt = date(year, 9, 29) + rd(weekday=MO)
-                elif year == 2019:
-                    dt = date(year, 9, 28) + rd(weekday=MO)
-                elif year == 2020:
-                    dt = date(year, 9, 26) + rd(weekday=MO)
+                dt = date(year, 9, 25) + rd(weekday=MO)
+                if year == 2011:
+                    dt = date(year, 10, 10) + rd(weekday=MO)
+                else:
+                    dt = date(year, 9, 25) + rd(weekday=MO)
                 if dt == labour_day:
-                    dt += rd(weekday=MO(+1))
-                self[date(year, 9, 26)] = name
+                    dt += rd(weekday=MO(+2))
+                self[dt] = name
 
         # Melbourne Cup
         if self.prov == 'VIC':

--- a/tests.py
+++ b/tests.py
@@ -3111,5 +3111,120 @@ class TestSweden(unittest.TestCase):
         self.assertFalse('2016-12-28' in self.holidays_with_sundays)
 
 
+class TestPoland(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays_without_sundays = holidays.Poland(include_sundays=False)
+        self.holidays_with_sundays = holidays.Poland()
+        self.holidays_all = holidays.Poland(public_only=False)
+
+    def test_new_years(self):
+        self.assertFalse('1900-01-01' in self.holidays_without_sundays)
+        self.assertTrue('2017-01-01' in self.holidays_without_sundays)
+        self.assertTrue('2999-01-01' in self.holidays_without_sundays)
+
+    def test_easter(self):
+        self.assertFalse('2000-04-20' in self.holidays_without_sundays)
+        self.assertFalse('2000-04-21' in self.holidays_without_sundays)
+        self.assertTrue('2000-04-23' in self.holidays_without_sundays)
+        self.assertTrue('2000-04-24' in self.holidays_without_sundays)
+
+        self.assertFalse('2010-04-01' in self.holidays_without_sundays)
+        self.assertFalse('2010-04-02' in self.holidays_without_sundays)
+        self.assertTrue('2010-04-04' in self.holidays_without_sundays)
+        self.assertTrue('2010-04-05' in self.holidays_without_sundays)
+
+        self.assertFalse('2021-04-01' in self.holidays_without_sundays)
+        self.assertFalse('2021-04-02' in self.holidays_without_sundays)
+        self.assertTrue('2021-04-04' in self.holidays_without_sundays)
+        self.assertTrue('2021-04-05' in self.holidays_without_sundays)
+
+        self.assertFalse('2024-03-28' in self.holidays_without_sundays)
+        self.assertFalse('2024-03-29' in self.holidays_without_sundays)
+        self.assertTrue('2024-03-31' in self.holidays_without_sundays)
+        self.assertTrue('2024-04-01' in self.holidays_without_sundays)
+
+    def test_workers_day(self):
+        self.assertFalse('1900-05-01' in self.holidays_without_sundays)
+        self.assertFalse('1946-05-01' in self.holidays_without_sundays)
+        self.assertTrue('1955-05-01' in self.holidays_without_sundays)
+        self.assertTrue('2017-05-01' in self.holidays_without_sundays)
+        self.assertTrue('2999-05-01' in self.holidays_without_sundays)
+
+    def test_constitution_day(self):
+        self.assertFalse('1900-05-03' in self.holidays_without_sundays)
+        self.assertFalse('1917-05-03' in self.holidays_without_sundays)
+        self.assertTrue('1947-05-03' in self.holidays_without_sundays)
+        self.assertTrue('2017-05-03' in self.holidays_without_sundays)
+        self.assertTrue('2999-05-03' in self.holidays_without_sundays)
+
+    def test_pentecost(self):
+        self.assertTrue('2000-06-11' in self.holidays_without_sundays)
+        self.assertFalse('2000-06-12' in self.holidays_without_sundays)
+
+        self.assertTrue('2010-05-23' in self.holidays_without_sundays)
+        self.assertFalse('2010-05-24' in self.holidays_without_sundays)
+
+        self.assertTrue('2021-05-23' in self.holidays_without_sundays)
+        self.assertFalse('2021-05-24' in self.holidays_without_sundays)
+
+        self.assertTrue('2024-05-19' in self.holidays_without_sundays)
+        self.assertFalse('2024-05-20' in self.holidays_without_sundays)
+
+    def test_christmas(self):
+        self.assertFalse('1901-12-25' in self.holidays_without_sundays)
+        self.assertFalse('1901-12-26' in self.holidays_without_sundays)
+
+        self.assertTrue('2016-12-25' in self.holidays_without_sundays)
+        self.assertTrue('2016-12-26' in self.holidays_without_sundays)
+
+        self.assertTrue('2500-12-25' in self.holidays_without_sundays)
+        self.assertTrue('2500-12-26' in self.holidays_without_sundays)
+
+    def test_sundays(self):
+        self.assertTrue('1989-12-31' in self.holidays_with_sundays)
+        self.assertTrue('2017-02-05' in self.holidays_with_sundays)
+        self.assertTrue('2017-02-12' in self.holidays_with_sundays)
+        self.assertTrue('2032-02-29' in self.holidays_with_sundays)
+
+    def test_not_holiday(self):
+        self.assertFalse('2017-02-06' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-07' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-08' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-09' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-10' in self.holidays_without_sundays)
+
+        self.assertFalse('2001-12-24' in self.holidays_without_sundays)
+        self.assertFalse('2001-05-16' in self.holidays_without_sundays)
+        self.assertFalse('2001-05-18' in self.holidays_without_sundays)
+        self.assertFalse('1999-12-31' in self.holidays_without_sundays)
+        self.assertFalse('2016-12-31' in self.holidays_without_sundays)
+        self.assertFalse('2016-12-27' in self.holidays_without_sundays)
+        self.assertFalse('2016-12-28' in self.holidays_without_sundays)
+
+        self.assertFalse('2017-02-06' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-07' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-08' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-09' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-10' in self.holidays_with_sundays)
+
+        self.assertFalse('2001-12-24' in self.holidays_with_sundays)
+        self.assertFalse('2001-05-16' in self.holidays_with_sundays)
+        self.assertFalse('2001-05-18' in self.holidays_with_sundays)
+        self.assertFalse('1999-12-31' in self.holidays_with_sundays)
+        self.assertFalse('2016-12-31' in self.holidays_with_sundays)
+        self.assertFalse('2016-12-27' in self.holidays_with_sundays)
+        self.assertFalse('2016-12-28' in self.holidays_with_sundays)
+
+    def test_not_public(self):
+        self.assertFalse('2016-12-28' in self.holidays_all)
+        self.assertFalse('2016-05-09' in self.holidays_all)
+        self.assertFalse('2010-03-01' in self.holidays_all)
+        self.assertTrue('2016-03-01' in self.holidays_all)
+        self.assertTrue('2012-08-31' in self.holidays_all)
+        self.assertTrue('1976-11-07' in self.holidays_all)
+        self.assertTrue('1981-07-22' in self.holidays_all)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -2039,14 +2039,14 @@ class TestNZ(unittest.TestCase):
             self.assertTrue(dt in stl_holidays, dt)
             self.assertEqual(stl_holidays[dt],
                              "Southland Anniversary Day", dt)
-            for year, (month, day) in enumerate([(4, 10), (4,  2), (4, 22),
-                                                 (4,  7), (3, 29), (4, 18),
-                                                 (4,  3), (4, 23), (4, 14),
-                                                 (4,  6)], 2012):
-                dt = date(year, month, day)
-                self.assertTrue(dt in stl_holidays, dt)
-                self.assertEqual(stl_holidays[dt],
-                                 "Southland Anniversary Day", dt)
+        for year, (month, day) in enumerate([(4, 10), (4,  2), (4, 22),
+                                             (4,  7), (3, 29), (4, 18),
+                                             (4,  3), (4, 23), (4, 14),
+                                             (4,  6)], 2012):
+            dt = date(year, month, day)
+            self.assertTrue(dt in stl_holidays, dt)
+            self.assertEqual(stl_holidays[dt],
+                             "Southland Anniversary Day", dt)
 
     def test_chatham_islands_anniversary_day(self):
         cit_holidays = holidays.NZ(prov='Chatham Islands')
@@ -2189,7 +2189,7 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.state_hols['WA'][dt], "Labour Day")
         for year, day in enumerate([10, 9, 14], 2014):
             dt = date(year, 3, day)
-            self.assertFalse(dt in self.holidays, dt)
+            self.assertNotEqual(self.holidays.get(dt), "Labour Day")
             self.assertTrue(dt in self.state_hols['VIC'], dt)
             self.assertEqual(self.state_hols['VIC'][dt], "Labour Day")
 
@@ -2247,10 +2247,19 @@ class TestAU(unittest.TestCase):
             self.assertTrue(dt in self.state_hols['NT'], dt)
             self.assertEqual(self.state_hols['NT'][dt], "Picnic Day")
 
+    def test_canberra_day(self):
+        for dt in [date(2013, 3, 11), date(2014, 3, 10), date(2015, 3, 9),
+                   date(2016, 3, 14), date(2017, 3, 13), date(2018, 3, 12),
+                   date(2019, 3, 11)]:
+            self.assertTrue(dt in self.state_hols['ACT'], dt)
+            self.assertEqual(self.state_hols['ACT'][dt],
+                             "Canberra Day")
+
     def test_family_and_community_day(self):
-        for dt in [date(2010, 9, 26), date(2011, 10, 10), date(2012, 10, 8),
+        for dt in [date(2010, 9, 27), date(2011, 10, 10), date(2012, 10, 8),
                    date(2013, 9, 30), date(2014, 9, 29), date(2015, 9, 28),
-                   date(2016, 9, 26)]:
+                   date(2016, 9, 26), date(2017, 9, 25), date(2018, 10, 8),
+                   date(2019, 9, 30)]:
             self.assertTrue(dt in self.state_hols['ACT'], dt)
             self.assertEqual(self.state_hols['ACT'][dt],
                              "Family & Community Day")

--- a/tests.py
+++ b/tests.py
@@ -3009,5 +3009,107 @@ class TestNorway(unittest.TestCase):
         self.assertFalse('2016-12-28' in self.holidays_with_sundays)
 
 
+class TestSweden(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays_without_sundays = holidays.Sweden(include_sundays=False)
+        self.holidays_with_sundays = holidays.Sweden()
+
+    def test_new_years(self):
+        self.assertTrue('1900-01-01' in self.holidays_without_sundays)
+        self.assertTrue('2017-01-01' in self.holidays_without_sundays)
+        self.assertTrue('2999-01-01' in self.holidays_without_sundays)
+
+    def test_easter(self):
+        self.assertFalse('2000-04-20' in self.holidays_without_sundays)
+        self.assertTrue('2000-04-21' in self.holidays_without_sundays)
+        self.assertTrue('2000-04-23' in self.holidays_without_sundays)
+        self.assertTrue('2000-04-24' in self.holidays_without_sundays)
+
+        self.assertFalse('2010-04-01' in self.holidays_without_sundays)
+        self.assertTrue('2010-04-02' in self.holidays_without_sundays)
+        self.assertTrue('2010-04-04' in self.holidays_without_sundays)
+        self.assertTrue('2010-04-05' in self.holidays_without_sundays)
+
+        self.assertFalse('2021-04-01' in self.holidays_without_sundays)
+        self.assertTrue('2021-04-02' in self.holidays_without_sundays)
+        self.assertTrue('2021-04-04' in self.holidays_without_sundays)
+        self.assertTrue('2021-04-05' in self.holidays_without_sundays)
+
+        self.assertFalse('2024-03-28' in self.holidays_without_sundays)
+        self.assertTrue('2024-03-29' in self.holidays_without_sundays)
+        self.assertTrue('2024-03-31' in self.holidays_without_sundays)
+        self.assertTrue('2024-04-01' in self.holidays_without_sundays)
+
+    def test_workers_day(self):
+        self.assertFalse('1800-05-01' in self.holidays_without_sundays)
+        self.assertFalse('1879-05-01' in self.holidays_without_sundays)
+        self.assertTrue('1890-05-01' in self.holidays_without_sundays)
+        self.assertTrue('2017-05-01' in self.holidays_without_sundays)
+        self.assertTrue('2999-05-01' in self.holidays_without_sundays)
+
+    def test_constitution_day(self):
+        self.assertFalse('1900-06-06' in self.holidays_without_sundays)
+        self.assertFalse('2004-06-06' in self.holidays_without_sundays)
+        self.assertTrue('2005-06-06' in self.holidays_without_sundays)
+        self.assertTrue('2017-06-06' in self.holidays_without_sundays)
+        self.assertTrue('2999-06-06' in self.holidays_without_sundays)
+
+    def test_pentecost(self):
+        self.assertTrue('2000-06-11' in self.holidays_without_sundays)
+        self.assertTrue('2000-06-12' in self.holidays_without_sundays)
+
+        self.assertTrue('2010-05-23' in self.holidays_without_sundays)
+        self.assertTrue('2010-05-24' in self.holidays_without_sundays)
+
+        self.assertTrue('2021-05-23' in self.holidays_without_sundays)
+        self.assertTrue('2021-05-24' in self.holidays_without_sundays)
+
+        self.assertTrue('2024-05-19' in self.holidays_without_sundays)
+        self.assertTrue('2024-05-20' in self.holidays_without_sundays)
+
+    def test_christmas(self):
+        self.assertTrue('1901-12-25' in self.holidays_without_sundays)
+        self.assertTrue('1901-12-26' in self.holidays_without_sundays)
+
+        self.assertTrue('2016-12-25' in self.holidays_without_sundays)
+        self.assertTrue('2016-12-26' in self.holidays_without_sundays)
+
+        self.assertTrue('2500-12-25' in self.holidays_without_sundays)
+        self.assertTrue('2500-12-26' in self.holidays_without_sundays)
+
+    def test_sundays(self):
+        """
+        Sundays are considered holidays in Sweden
+        :return:
+        """
+        self.assertTrue('1989-12-31' in self.holidays_with_sundays)
+        self.assertTrue('2017-02-05' in self.holidays_with_sundays)
+        self.assertTrue('2017-02-12' in self.holidays_with_sundays)
+        self.assertTrue('2032-02-29' in self.holidays_with_sundays)
+
+    def test_not_holiday(self):
+        """
+        Note: Sundays in Sweden are considered holidays,
+        so make sure none of these are actually sundays
+        :return:
+        """
+        self.assertFalse('2017-02-06' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-07' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-08' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-09' in self.holidays_without_sundays)
+        self.assertFalse('2017-02-10' in self.holidays_without_sundays)
+        self.assertFalse('2016-12-27' in self.holidays_without_sundays)
+        self.assertFalse('2016-12-28' in self.holidays_without_sundays)
+
+        self.assertFalse('2017-02-06' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-07' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-08' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-09' in self.holidays_with_sundays)
+        self.assertFalse('2017-02-10' in self.holidays_with_sundays)
+        self.assertFalse('2016-12-27' in self.holidays_with_sundays)
+        self.assertFalse('2016-12-28' in self.holidays_with_sundays)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -2110,8 +2110,8 @@ class TestAU(unittest.TestCase):
 
     def setUp(self):
         self.holidays = holidays.AU(observed=True)
-        self.state_hols = dict((state, holidays.AU(observed=True, prov=state))
-                               for state in holidays.AU.PROVINCES)
+        self.state_hols = dict((s, holidays.AU(observed=True, state=s))
+                               for s in holidays.AU.STATES)
 
     def test_new_years(self):
         for year in range(1900, 2100):
@@ -2135,7 +2135,7 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.holidays[jan26], "Australia Day")
             self.assertTrue(dt in self.holidays, dt)
             self.assertEqual(self.holidays[dt][:10], "Australia ")
-            for state in holidays.AU.PROVINCES:
+            for state in holidays.AU.STATES:
                 self.assertTrue(jan26 in self.state_hols[state], (state, dt))
                 self.assertEqual(self.state_hols[state][jan26],
                                  "Australia Day")
@@ -2311,8 +2311,8 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.holidays[dt][:6], "Boxing")
 
     def test_all_holidays_present(self):
-        au_2015 = sum(holidays.AU(years=[2015], prov=p)
-                      for p in holidays.AU.PROVINCES)
+        au_2015 = sum(holidays.AU(years=[2015], state=s)
+                      for s in holidays.AU.STATES)
         holidays_in_2015 = sum((au_2015.get_list(key) for key in au_2015), [])
         all_holidays = ["New Year's Day",
                         "Australia Day",


### PR DESCRIPTION
I am the one who created the Australia country class with it taking a prov argument.  Now that the library is much more developed and HolidayBase can also take a state argument I think Australians would prefer to use that (even though ACT and NT are territories, not states).  I have changed this, and have also removed ACT as a default, and fixed the handling of Canberra Day and Family & Community Day for ACT.

NOTE:  I have not made any attempt at maintaining backwards compatibility.  Is this required?  If so I could add some code for that.