### PR TITLE
Australia

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Available Countries
 =================== ======== =============================================================
 Country             Abbr     Provinces/States Available
 =================== ======== =============================================================
-Australia           AU       prov = **ACT** (default), NSW, NT, QLD, SA, TAS, VIC, WA
+Australia           AU       state = ACT, NSW, NT, QLD, SA, TAS, VIC, WA
 Austria             AT       prov = B, K, N, O, S, ST, T, V, **W** (default)
 Canada              CA       prov = AB, BC, MB, NB, NL, NS, NT, NU, **ON** (default),
                              PE, QC, SK, YU
@@ -140,11 +140,11 @@ observed
 
 prov
     A string specifying a province that has unique statutory holidays.
-    (Default: Australia='ACT', Canada='ON', NewZealand=None)
+    (Default: Canada='ON', NewZealand=None)
 
 state
     A string specifying a state that has unique statutory holidays.
-    (Default: UnitedStates=None)
+    (Default: Australia=None, UnitedStates=None)
 
 Methods:
 

--- a/holidays.py
+++ b/holidays.py
@@ -1303,11 +1303,10 @@ class NZ(NewZealand):
 
 
 class Australia(HolidayBase):
-    PROVINCES = ['ACT', 'NSW', 'NT', 'QLD', 'SA', 'TAS', 'VIC', 'WA']
+    STATES = ['ACT', 'NSW', 'NT', 'QLD', 'SA', 'TAS', 'VIC', 'WA']
 
     def __init__(self, **kwargs):
         self.country = 'AU'
-        self.prov = kwargs.pop('prov', kwargs.pop('state', 'ACT'))
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
@@ -1330,19 +1329,19 @@ class Australia(HolidayBase):
         # Australia Day
         jan26 = date(year, 1, 26)
         if year >= 1935:
-            if self.prov == 'NSW' and year < 1946:
+            if self.state == 'NSW' and year < 1946:
                 name = "Anniversary Day"
             else:
                 name = "Australia Day"
             self[jan26] = name
             if self.observed and year >= 1946 and jan26.weekday() in WEEKEND:
                 self[jan26 + rd(weekday=MO)] = name + " (Observed)"
-        elif year >= 1888 and self.prov != 'SA':
+        elif year >= 1888 and self.state != 'SA':
             name = "Anniversary Day"
             self[jan26] = name
 
         # Adelaide Cup
-        if self.prov == 'SA':
+        if self.state == 'SA':
             name = "Adelaide Cup"
             if year >= 2006:
                 # subject to proclamation ?!?!
@@ -1351,15 +1350,15 @@ class Australia(HolidayBase):
                 self[date(year, 3, 1) + rd(weekday=MO(+3))] = name
 
         # Canberra Day
-        if self.prov == 'ACT':
+        if self.state == 'ACT':
             name = "Canberra Day"
             self[date(year, 3, 1) + rd(weekday=MO(+2))] = name
 
         # Easter
         self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
-        if self.prov in ('ACT', 'NSW', 'NT', 'QLD', 'SA', 'VIC'):
+        if self.state in ('ACT', 'NSW', 'NT', 'QLD', 'SA', 'VIC'):
             self[easter(year) + rd(weekday=SA(-1))] = "Easter Saturday"
-        if self.prov == 'NSW':
+        if self.state == 'NSW':
             self[easter(year)] = "Easter Sunday"
         self[easter(year) + rd(weekday=MO)] = "Easter Monday"
 
@@ -1369,14 +1368,14 @@ class Australia(HolidayBase):
             apr25 = date(year, 4, 25)
             self[apr25] = name
             if self.observed:
-                if apr25.weekday() == SATURDAY and self.prov in ('WA', 'NT'):
+                if apr25.weekday() == SATURDAY and self.state in ('WA', 'NT'):
                     self[apr25 + rd(weekday=MO)] = name + " (Observed)"
                 elif (apr25.weekday() == SUNDAY and
-                      self.prov in ('ACT', 'QLD', 'SA', 'WA', 'NT')):
+                      self.state in ('ACT', 'QLD', 'SA', 'WA', 'NT')):
                     self[apr25 + rd(weekday=MO)] = name + " (Observed)"
 
         # Western Australia Day
-        if self.prov == 'WA' and year > 1832:
+        if self.state == 'WA' and year > 1832:
             if year >= 2015:
                 name = "Western Australia Day"
             else:
@@ -1390,14 +1389,14 @@ class Australia(HolidayBase):
             name = "King's Birthday"
         if year >= 1936:
             name = "Queen's Birthday"
-            if self.prov == 'QLD':
+            if self.state == 'QLD':
                 if year == 2012:
                     self[date(year, 10, 1)] = name
                     self[date(year, 6, 11)] = "Queen's Diamond Jubilee"
                 else:
                     dt = date(year, 6, 1) + rd(weekday=MO(+2))
                     self[dt] = name
-            elif self.prov == 'WA':
+            elif self.state == 'WA':
                 # by proclamation ?!?!
                 self[date(year, 10, 1) + rd(weekday=MO(-1))] = name
             else:
@@ -1409,32 +1408,32 @@ class Australia(HolidayBase):
             self[date(year, 11, 9)] = name  # Edward VII
 
         # Picnic Day
-        if self.prov == 'NT':
+        if self.state == 'NT':
             name = "Picnic Day"
             self[date(year, 8, 1) + rd(weekday=MO)] = name
 
         # Labour Day
         name = "Labour Day"
-        if self.prov in ('NSW', 'ACT', 'SA'):
+        if self.state in ('NSW', 'ACT', 'SA'):
             self[date(year, 10, 1) + rd(weekday=MO)] = name
-        elif self.prov == 'WA':
+        elif self.state == 'WA':
             self[date(year, 3, 1) + rd(weekday=MO)] = name
-        elif self.prov == 'VIC':
+        elif self.state == 'VIC':
             self[date(year, 3, 1) + rd(weekday=MO(+2))] = name
-        elif self.prov == 'QLD':
+        elif self.state == 'QLD':
             if 2013 <= year <= 2015:
                 self[date(year, 10, 1) + rd(weekday=MO)] = name
             else:
                 self[date(year, 5, 1) + rd(weekday=MO)] = name
-        elif self.prov == 'NT':
+        elif self.state == 'NT':
             name = "May Day"
             self[date(year, 5, 1) + rd(weekday=MO)] = name
-        elif self.prov == 'TAS':
+        elif self.state == 'TAS':
             name = "Eight Hours Day"
             self[date(year, 3, 1) + rd(weekday=MO(+2))] = name
 
         # Family & Community Day
-        if self.prov == 'ACT':
+        if self.state == 'ACT':
             name = "Family & Community Day"
             if 2007 <= year <= 2009:
                 self[date(year, 11, 1) + rd(weekday=TU)] = name
@@ -1454,7 +1453,7 @@ class Australia(HolidayBase):
                 self[dt] = name
 
         # Melbourne Cup
-        if self.prov == 'VIC':
+        if self.state == 'VIC':
             name = "Melbourne Cup"
             self[date(year, 11, 1) + rd(weekday=TU)] = name
 
@@ -1466,7 +1465,7 @@ class Australia(HolidayBase):
             self[date(year, 12, 27)] = name + " (Observed)"
 
         # Boxing Day
-        if self.prov == 'SA':
+        if self.state == 'SA':
             name = "Proclamation Day"
         else:
             name = "Boxing Day"

--- a/holidays.py
+++ b/holidays.py
@@ -1320,8 +1320,6 @@ class Australia(HolidayBase):
         # VIC:  Public Holidays Act 1993
         # WA:   Public and Bank Holidays Act 1972
 
-        # TODO do more research on history of Aus holidays
-
         # New Year's Day
         name = "New Year's Day"
         jan1 = date(year, 1, 1)
@@ -1355,7 +1353,7 @@ class Australia(HolidayBase):
         # Canberra Day
         if self.prov == 'ACT':
             name = "Canberra Day"
-            self[date(year, 3, 1) + rd(weekday=MO(+1))] = name
+            self[date(year, 3, 1) + rd(weekday=MO(+2))] = name
 
         # Easter
         self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
@@ -1440,37 +1438,20 @@ class Australia(HolidayBase):
             name = "Family & Community Day"
             if 2007 <= year <= 2009:
                 self[date(year, 11, 1) + rd(weekday=TU)] = name
-            elif year == 2010:
-                # first Monday of the September/October school holidays
+            else:
+                # First Monday of the September/October school holidays
                 # moved to the second Monday if this falls on Labour day
-                # TODO need a formula for the ACT school holidays then
+                # The following formula works until at least 2020
                 # http://www.cmd.act.gov.au/communication/holidays
-                self[date(year, 9, 26)] = name
-            elif year == 2011:
-                self[date(year, 10, 10)] = name
-            elif year == 2012:
-                self[date(year, 10, 8)] = name
-            elif year == 2013:
-                self[date(year, 9, 30)] = name
-            elif year == 2014:
-                self[date(year, 9, 29)] = name
-            elif year == 2015:
-                self[date(year, 9, 28)] = name
-            elif year == 2016:
-                self[date(year, 9, 26)] = name
-            elif 2017 <= year <= 2020:
                 labour_day = date(year, 10, 1) + rd(weekday=MO)
-                if year == 2017:
-                    dt = date(year, 9, 23) + rd(weekday=MO)
-                elif year == 2018:
-                    dt = date(year, 9, 29) + rd(weekday=MO)
-                elif year == 2019:
-                    dt = date(year, 9, 28) + rd(weekday=MO)
-                elif year == 2020:
-                    dt = date(year, 9, 26) + rd(weekday=MO)
+                dt = date(year, 9, 25) + rd(weekday=MO)
+                if year == 2011:
+                    dt = date(year, 10, 10) + rd(weekday=MO)
+                else:
+                    dt = date(year, 9, 25) + rd(weekday=MO)
                 if dt == labour_day:
-                    dt += rd(weekday=MO(+1))
-                self[date(year, 9, 26)] = name
+                    dt += rd(weekday=MO(+2))
+                self[dt] = name
 
         # Melbourne Cup
         if self.prov == 'VIC':

--- a/tests.py
+++ b/tests.py
@@ -2039,14 +2039,14 @@ class TestNZ(unittest.TestCase):
             self.assertTrue(dt in stl_holidays, dt)
             self.assertEqual(stl_holidays[dt],
                              "Southland Anniversary Day", dt)
-            for year, (month, day) in enumerate([(4, 10), (4,  2), (4, 22),
-                                                 (4,  7), (3, 29), (4, 18),
-                                                 (4,  3), (4, 23), (4, 14),
-                                                 (4,  6)], 2012):
-                dt = date(year, month, day)
-                self.assertTrue(dt in stl_holidays, dt)
-                self.assertEqual(stl_holidays[dt],
-                                 "Southland Anniversary Day", dt)
+        for year, (month, day) in enumerate([(4, 10), (4,  2), (4, 22),
+                                             (4,  7), (3, 29), (4, 18),
+                                             (4,  3), (4, 23), (4, 14),
+                                             (4,  6)], 2012):
+            dt = date(year, month, day)
+            self.assertTrue(dt in stl_holidays, dt)
+            self.assertEqual(stl_holidays[dt],
+                             "Southland Anniversary Day", dt)
 
     def test_chatham_islands_anniversary_day(self):
         cit_holidays = holidays.NZ(prov='Chatham Islands')
@@ -2189,7 +2189,7 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.state_hols['WA'][dt], "Labour Day")
         for year, day in enumerate([10, 9, 14], 2014):
             dt = date(year, 3, day)
-            self.assertFalse(dt in self.holidays, dt)
+            self.assertNotEqual(self.holidays.get(dt), "Labour Day")
             self.assertTrue(dt in self.state_hols['VIC'], dt)
             self.assertEqual(self.state_hols['VIC'][dt], "Labour Day")
 
@@ -2247,10 +2247,19 @@ class TestAU(unittest.TestCase):
             self.assertTrue(dt in self.state_hols['NT'], dt)
             self.assertEqual(self.state_hols['NT'][dt], "Picnic Day")
 
+    def test_canberra_day(self):
+        for dt in [date(2013, 3, 11), date(2014, 3, 10), date(2015, 3, 9),
+                   date(2016, 3, 14), date(2017, 3, 13), date(2018, 3, 12),
+                   date(2019, 3, 11)]:
+            self.assertTrue(dt in self.state_hols['ACT'], dt)
+            self.assertEqual(self.state_hols['ACT'][dt],
+                             "Canberra Day")
+
     def test_family_and_community_day(self):
-        for dt in [date(2010, 9, 26), date(2011, 10, 10), date(2012, 10, 8),
+        for dt in [date(2010, 9, 27), date(2011, 10, 10), date(2012, 10, 8),
                    date(2013, 9, 30), date(2014, 9, 29), date(2015, 9, 28),
-                   date(2016, 9, 26)]:
+                   date(2016, 9, 26), date(2017, 9, 25), date(2018, 10, 8),
+                   date(2019, 9, 30)]:
             self.assertTrue(dt in self.state_hols['ACT'], dt)
             self.assertEqual(self.state_hols['ACT'][dt],
                              "Family & Community Day")

--- a/tests.py
+++ b/tests.py
@@ -2110,8 +2110,8 @@ class TestAU(unittest.TestCase):
 
     def setUp(self):
         self.holidays = holidays.AU(observed=True)
-        self.state_hols = dict((state, holidays.AU(observed=True, prov=state))
-                               for state in holidays.AU.PROVINCES)
+        self.state_hols = dict((s, holidays.AU(observed=True, state=s))
+                               for s in holidays.AU.STATES)
 
     def test_new_years(self):
         for year in range(1900, 2100):
@@ -2135,7 +2135,7 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.holidays[jan26], "Australia Day")
             self.assertTrue(dt in self.holidays, dt)
             self.assertEqual(self.holidays[dt][:10], "Australia ")
-            for state in holidays.AU.PROVINCES:
+            for state in holidays.AU.STATES:
                 self.assertTrue(jan26 in self.state_hols[state], (state, dt))
                 self.assertEqual(self.state_hols[state][jan26],
                                  "Australia Day")
@@ -2311,8 +2311,8 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.holidays[dt][:6], "Boxing")
 
     def test_all_holidays_present(self):
-        au_2015 = sum(holidays.AU(years=[2015], prov=p)
-                      for p in holidays.AU.PROVINCES)
+        au_2015 = sum(holidays.AU(years=[2015], state=s)
+                      for s in holidays.AU.STATES)
         holidays_in_2015 = sum((au_2015.get_list(key) for key in au_2015), [])
         all_holidays = ["New Year's Day",
                         "Australia Day",


### PR DESCRIPTION
I am the one who created the Australia country class with it taking a prov argument. Now that the library is much more developed and HolidayBase can also take a state argument I think Australians would prefer to use that (even though ACT and NT are territories, not states). I have changed this, and have also removed ACT as a default, and fixed the handling of Canberra Day and Family & Community Day for ACT.

NOTE: I have not made any attempt at maintaining backwards compatibility. Is this required? If so I could add some code for that.