### PR TITLE
Add one-off national Reformation day (DE/2017)

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -1581,7 +1581,7 @@ class Germany(HolidayBase):
 
             self[date(year, 10, 3)] = 'Tag der Deutschen Einheit'
 
-        if self.prov in ('BB', 'MV', 'SN', 'ST', 'TH'):
+        if self.prov in ('BB', 'MV', 'SN', 'ST', 'TH') or year == 2017:
             self[date(year, 10, 31)] = 'Reformationstag'
 
         if self.prov in ('BW', 'BY', 'NW', 'RP', 'SL'):

--- a/tests.py
+++ b/tests.py
@@ -2480,7 +2480,13 @@ class TestDE(unittest.TestCase):
         for province, year in product(provinces_that_have, range(1991, 2050)):
             self.assertTrue(date(year, 10, 31) in self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1991, 2050)):
+            if year == 2017:
+                continue
             self.assertTrue(date(year, 10, 31) not in self.prov_hols[province])
+
+        # In 2017, the states that don't normally have it, do.
+        for province in provinces_that_dont:
+            self.assertTrue(date(2017, 10, 31) in self.prov_hols[province])
 
     def test_allerheiligen(self):
         provinces_that_have = set(('BW', 'BY', 'NW', 'RP', 'SL'))


### PR DESCRIPTION
This library is missing a national holiday in Germany that is coming up soon.

Germany is celebrating the 500th anniversary of Reformation day by making it a national public holiday on 2017-10-31. Normally it is only a public holiday in a few states. See eg https://en.wikipedia.org/wiki/Reformation_Day#500th_anniversary