### PR TITLE
add public holiday Reformationstag in 2017 for Germany

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -1583,6 +1583,10 @@ class Germany(HolidayBase):
 
         if self.prov in ('BB', 'MV', 'SN', 'ST', 'TH'):
             self[date(year, 10, 31)] = 'Reformationstag'
+        elif year == 2017:
+            # 500 years of ninety-five theses:
+            # Reformationstag is a public holiday in all prov of Germany
+            self[date(year, 10, 31)] = 'Reformationstag'
 
         if self.prov in ('BW', 'BY', 'NW', 'RP', 'SL'):
             self[date(year, 11, 1)] = 'Allerheiligen'

--- a/tests.py
+++ b/tests.py
@@ -2479,8 +2479,14 @@ class TestDE(unittest.TestCase):
 
         for province, year in product(provinces_that_have, range(1991, 2050)):
             self.assertTrue(date(year, 10, 31) in self.prov_hols[province])
-        for province, year in product(provinces_that_dont, range(1991, 2050)):
+        for province, year in product(provinces_that_dont, range(1991, 2017)):
             self.assertTrue(date(year, 10, 31) not in self.prov_hols[province])
+        for province, year in product(provinces_that_dont, range(2018, 2050)):
+            self.assertTrue(date(year, 10, 31) not in self.prov_hols[province])
+
+        # in 2017 Reformationstag is a public holiday in all prov of Germany
+        for province, year in product(self.prov_hols, [2017]):
+            self.assertTrue(date(year, 10, 31) in self.prov_hols[province])
 
     def test_allerheiligen(self):
         provinces_that_have = set(('BW', 'BY', 'NW', 'RP', 'SL'))


### PR DESCRIPTION
in germany 2017 is the Luther year:

https://www.tk.de/tk/beitraege/faelligkeit/reformationstag/922098