### PR TITLE
Fixed Germany's Reformationstag for 2017

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -1584,6 +1584,11 @@ class Germany(HolidayBase):
         if self.prov in ('BB', 'MV', 'SN', 'ST', 'TH'):
             self[date(year, 10, 31)] = 'Reformationstag'
 
+        # in 2017 all states got the Reformationstag (500th anniversary of
+        # Luther's thesis)
+        if year == 2017:
+            self[date(year, 10, 31)] = 'Reformationstag'
+
         if self.prov in ('BW', 'BY', 'NW', 'RP', 'SL'):
             self[date(year, 11, 1)] = 'Allerheiligen'
 

--- a/tests.py
+++ b/tests.py
@@ -2478,9 +2478,18 @@ class TestDE(unittest.TestCase):
         provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
 
         for province, year in product(provinces_that_have, range(1991, 2050)):
+            # in 2017 all states got the reformationstag for that year
+            if year == 2017:
+                continue
             self.assertTrue(date(year, 10, 31) in self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1991, 2050)):
+            # in 2017 all states got the reformationstag for that year
+            if year == 2017:
+                continue
             self.assertTrue(date(year, 10, 31) not in self.prov_hols[province])
+        # check the 2017 case where all states have the reformationstag
+        for province in holidays.DE.PROVINCES:
+            self.assertTrue(date(2017, 10, 31) in self.prov_hols[province])
 
     def test_allerheiligen(self):
         provinces_that_have = set(('BW', 'BY', 'NW', 'RP', 'SL'))


### PR DESCRIPTION
In 2017 the Reformationstag was granted to all states in Germany for the
500th anniversary of Luther's thesis. Note this rule only applies to
2017.

Added the fix and the tests.

Fixes #68