### PR TITLE
Fix E722 do not use bare 'except'

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -68,7 +68,7 @@ class HolidayBase(dict):
         elif isinstance(key, six.string_types):
             try:
                 key = parse(key).date()
-            except:
+            except Exception:
                 raise ValueError("Cannot parse date from string '%s'" % key)
         else:
             raise TypeError("Cannot convert type '%s' to date." % type(key))


### PR DESCRIPTION
Fixes https://github.com/ryanss/python-holidays/issues/77 and fixes the flake8 build.

I guess the general idea of the warning is to catch more specific exceptions, but it can be hard to know what the intention was with old code so this is fine. In the future let's be more specific with new ones.